### PR TITLE
Use --mirror; clean up /tmp; don't rm s3 artifact

### DIFF
--- a/github-to-s3
+++ b/github-to-s3
@@ -13,7 +13,7 @@ ARCHIVE_PATH=/tmp/$NAME.tar.gz
 REPOSITORY_PATH=/tmp/$NAME
 
 rm -rf $REPOSITORY_PATH
-git clone git@github.com:$1 $REPOSITORY_PATH
+git clone --mirror git@github.com:$1 $REPOSITORY_PATH
 
 rm -rf $ARCHIVE_PATH
 tar -C /tmp -zcf $ARCHIVE_PATH $NAME

--- a/github-to-s3
+++ b/github-to-s3
@@ -21,3 +21,4 @@ tar -C /tmp -zcf $ARCHIVE_PATH $NAME
 aws s3 mv $ARCHIVE_PATH s3://$GITHUB_S3_BUCKET/$NAME.tar.gz
 
 curl -X DELETE -H "Authorization: token $GITHUB_S3_GITHUB_TOKEN" https://api.github.com/repos/$1
+rm -rf $REPOSITORY_PATH $ARCHIVE_PATH

--- a/github-to-s3
+++ b/github-to-s3
@@ -14,7 +14,6 @@ REPOSITORY_PATH=/tmp/$NAME
 
 rm -rf $REPOSITORY_PATH
 git clone --mirror git@github.com:$1 $REPOSITORY_PATH
-(cd $REPOSITORY_PATH && git fetch --tags)
 
 rm -rf $ARCHIVE_PATH
 tar -C /tmp -zcf $ARCHIVE_PATH $NAME

--- a/github-to-s3
+++ b/github-to-s3
@@ -14,6 +14,7 @@ REPOSITORY_PATH=/tmp/$NAME
 
 rm -rf $REPOSITORY_PATH
 git clone --mirror git@github.com:$1 $REPOSITORY_PATH
+(cd $REPOSITORY_PATH && git fetch --tags)
 
 rm -rf $ARCHIVE_PATH
 tar -C /tmp -zcf $ARCHIVE_PATH $NAME

--- a/s3-to-github
+++ b/s3-to-github
@@ -23,5 +23,5 @@ curl -s -X POST -H "Authorization: token $GITHUB_S3_GITHUB_TOKEN" \
   https://api.github.com/orgs/$GITHUB_ORGANIZATION_NAME/repos \
   -d "{\"name\":\"$GITHUB_REPOSITORY_NAME\", \"private\": true}" > /dev/null
 
-git -C $REPOSITORY_PATH push
+git -C $REPOSITORY_PATH push --mirror
 rm -rf $REPOSITORY_PATH $ARCHIVE_PATH

--- a/s3-to-github
+++ b/s3-to-github
@@ -24,3 +24,4 @@ curl -s -X POST -H "Authorization: token $GITHUB_S3_GITHUB_TOKEN" \
   -d "{\"name\":\"$GITHUB_REPOSITORY_NAME\", \"private\": true}" > /dev/null
 
 git -C $REPOSITORY_PATH push
+rm -rf $REPOSITORY_PATH $ARCHIVE_PATH

--- a/s3-to-github
+++ b/s3-to-github
@@ -14,7 +14,7 @@ NAME=$(echo $GITHUB_PATH | sed 's/\//-/')
 ARCHIVE_PATH=/tmp/$NAME.tar.gz
 REPOSITORY_PATH=/tmp/$NAME
 
-aws s3 mv s3://$GITHUB_S3_BUCKET/$NAME.tar.gz /tmp
+aws s3 cp s3://$GITHUB_S3_BUCKET/$NAME.tar.gz /tmp
 
 rm -rf $REPOSITORY_PATH
 tar -C /tmp -xf $ARCHIVE_PATH


### PR DESCRIPTION
Thank you for this project - it saved me a bunch of time.

Here are a few changes I had to make to fit my usecase. In particular, I think --mirror is important to grab all tags and branches. The rest is more behavioral and based on how we want to run the script.
